### PR TITLE
Change [ftr123] to [123] in merge commit message

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -48,10 +48,11 @@ class MergeJob(object):
             raise CannotMerge("Could you give this MR a meaningful title? Remove emoji "
                               ":construction: when it's good to go.")
 
-        # check source branch name
-        reobj = re.compile(r"^(\d{1,})\-\w{3}\1")
-        if not reobj.match(merge_request.source_branch):
-            raise CannotMerge("Branch name is not in correct format.")
+        # check if source branch name is valid
+        if not re.match("^\d+\-.+", merge_request.source_branch):
+            raise CannotMerge("Invalid source branch name. It should be like 1234-fix-the-bug. "
+                              "Regex: `^\d+\-.+`.")
+
 
         if merge_request.work_in_progress:
             raise CannotMerge("Sorry, I can't merge requests marked as Work-In-Progress!")

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -69,7 +69,7 @@ class SingleMergeJob(MergeJob):
             try:
                 source_branch = merge_request.source_branch.split("-")
                 merge_message = "[{issue_id}] {MR_title}".format(
-                    issue_id=source_branch[1].upper(),
+                    issue_id=source_branch[0],
                     MR_title=merge_request.title)
                 merge_request.accept(remove_branch=True, sha=merge_request.sha, merge_message=merge_message)
                 merge_request.unassign()


### PR DESCRIPTION
After this MR,
- marge-bot will reject any MR whose source branch name does not match `^\d+\-.+`. 
- The merge commit message will become `[123] Blah Blah`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/marge-bot/11)
<!-- Reviewable:end -->
